### PR TITLE
Add noopener noreferrer when target="_blank"

### DIFF
--- a/js/scripts.js
+++ b/js/scripts.js
@@ -27,7 +27,7 @@ function showTweet(tweets){
   var html = 
       '<ul class="twitter">'
        + '<li class="tweet-body">' + tweetObject.tweet + '</li>'
-       + '<li class="tweet-info">' + '<a href="' + tweetObject.permalinkURL + '" target="_blank">' + tweetObject.time + '</a>' + '</li>'
+       + '<li class="tweet-info">' + '<a href="' + tweetObject.permalinkURL + '" target="_blank" rel="noopener noreferrer">' + tweetObject.time + '</a>' + '</li>'
     + '</ul>';
 
   element.innerHTML = html;


### PR DESCRIPTION
`target="_blank"` is a small security problem, as explained [here](https://dev.to/ben/the-targetblank-vulnerability-by-example). I don't think twitter will every exploit that, but why leave this flaw?
